### PR TITLE
feat(Persistence): SaveSystem implemented and tested

### DIFF
--- a/SwiftUIQuizz.xcodeproj/project.pbxproj
+++ b/SwiftUIQuizz.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3DFD23EE28295C180074AB54 /* Manager.SaveSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFD23ED28295C180074AB54 /* Manager.SaveSystem.swift */; };
 		5F3AC735282408030041CBBC /* Manager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3AC734282408030041CBBC /* Manager.swift */; };
 		5F3AC737282408250041CBBC /* Manager.API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3AC736282408250041CBBC /* Manager.API.swift */; };
 		5FDC436B282936FF00A4F011 /* LottieSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 5FDC436A282936FF00A4F011 /* LottieSwiftUI */; };
@@ -22,6 +23,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3DFD23ED28295C180074AB54 /* Manager.SaveSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Manager.SaveSystem.swift; sourceTree = "<group>"; };
 		5F3AC734282408030041CBBC /* Manager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Manager.swift; sourceTree = "<group>"; };
 		5F3AC736282408250041CBBC /* Manager.API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Manager.API.swift; sourceTree = "<group>"; };
 		5FDC436C2829371100A4F011 /* LaunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchView.swift; sourceTree = "<group>"; };
@@ -53,6 +55,7 @@
 			children = (
 				5F3AC734282408030041CBBC /* Manager.swift */,
 				5F3AC736282408250041CBBC /* Manager.API.swift */,
+				3DFD23ED28295C180074AB54 /* Manager.SaveSystem.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -223,6 +226,7 @@
 				5F3AC737282408250041CBBC /* Manager.API.swift in Sources */,
 				5FDC436D2829371100A4F011 /* LaunchView.swift in Sources */,
 				5FE9134A2822A76E00C0CDE0 /* QuestionView.swift in Sources */,
+				3DFD23EE28295C180074AB54 /* Manager.SaveSystem.swift in Sources */,
 				5FE913482822A76E00C0CDE0 /* SwiftUIQuizzApp.swift in Sources */,
 				5FE913592822B96F00C0CDE0 /* Views.swift in Sources */,
 				5FDC437428294C6600A4F011 /* InitialView.swift in Sources */,

--- a/SwiftUIQuizz/Manager/Manager.SaveSystem.swift
+++ b/SwiftUIQuizz/Manager/Manager.SaveSystem.swift
@@ -1,0 +1,119 @@
+//
+//  DataManager.swift
+//  SwiftUIQuizz
+//
+//  Created by Henrique Finger Zimerman on 09/05/22.
+//
+
+import Foundation
+
+extension Manager {
+    class SaveSystem {
+        enum SaveSystemError: Error {
+            case invalidDirPath
+            case fileDoesNotExist
+            case failedWriting
+            case failedReading
+            case invalidStringEncoding
+            case invalidObject
+        }
+
+        static func fileExists(fileName: String) -> Bool {
+            guard let dirUrl = try? FileManager.default.url(for: .documentDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true)
+            else {
+                return false
+            }
+
+            let fileUrl = dirUrl.appendingPathComponent(fileName)
+                                .appendingPathExtension("json")
+            return FileManager.default.fileExists(atPath: fileUrl.path)
+        }
+
+        static func saveToFile(content: String, fileName: String) throws {
+            guard let dirUrl = try? FileManager.default.url(
+                for: .documentDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true)
+            else {
+                throw SaveSystemError.invalidDirPath
+            }
+
+            let fileUrl = dirUrl.appendingPathComponent(fileName)
+                                .appendingPathExtension("json")
+
+            do {
+                try content.write(to: fileUrl,
+                                     atomically: true,
+                                     encoding: String.Encoding.utf8)
+            } catch {
+                throw SaveSystemError.failedWriting
+            }
+        }
+
+        static func readFromFile(fileName: String) throws -> String {
+            guard let dirUrl = try? FileManager.default.url(for: .documentDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true)
+            else {
+                throw SaveSystemError.invalidDirPath
+            }
+
+            let fileUrl = dirUrl.appendingPathComponent(fileName)
+                                .appendingPathExtension("json")
+
+            guard FileManager.default.fileExists(atPath: fileUrl.path)
+            else {
+                throw SaveSystemError.fileDoesNotExist
+            }
+
+            do {
+                let fileContents = try String(contentsOf: fileUrl)
+                return fileContents
+            } catch {
+                throw SaveSystemError.failedReading
+            }
+        }
+
+        static func objectFromJson<T: Decodable>(json: String) throws -> T {
+            guard let jsonData = json.data(using: .utf8)
+            else {
+                throw SaveSystemError.invalidStringEncoding
+            }
+
+            let decoder = JSONDecoder()
+            do {
+                return try decoder.decode(T.self, from: jsonData)
+            } catch {
+                throw SaveSystemError.invalidObject
+            }
+        }
+
+        static func objectToJson<T: Encodable>(object: T) throws -> String {
+            do {
+                let jsonData = try JSONEncoder().encode(object)
+                guard let stringData = String(data: jsonData, encoding: .utf8)
+                else {
+                    throw SaveSystemError.invalidStringEncoding
+                }
+                return stringData
+            } catch {
+                throw SaveSystemError.invalidObject
+            }
+        }
+
+        static func saveObject<T: Encodable>(object: T, fileName: String) throws {
+            let objectJson = try objectToJson(object: object)
+            try saveToFile(content: objectJson, fileName: fileName)
+        }
+
+        static func readObject<T: Decodable>(fileName: String) throws -> T {
+            let objectJson = try readFromFile(fileName: fileName)
+            return try objectFromJson(json: objectJson)
+        }
+    }
+}


### PR DESCRIPTION
Implemented the SaveSystem static Class inside the Manager namespace.

Class has 7 static methods:

- file exists
    static func fileExists(fileName: String) -> Bool
- saveToFile
    static func saveToFile(content: String, fileName: String) throws
- readFromFile
    static func readFromFile(fileName: String) throws -> String
- objectFromJson
    static func objectFromJson<T: Decodable>(json: String) throws -> T
- objectToJson
    static func objectToJson<T: Encodable>(object: T) throws -> String
- saveObject
    static func saveObject<T: Encodable>(object: T, fileName: String)
- readObject
    static func readObject<T: Decodable>(fileName: String) throws -> T

The class also has its own errors:

enum SaveSystemError: Error {
          case invalidDirPath
          case fileDoesNotExist
          case failedWriting
          case failedReading
          case invalidStringEncoding
          case invalidObject
}

Class was tested in a Playground.