### PR TITLE
feat(Question Stash and Session Manager): Add question stash and fetch strategy, added a Session Manager.

### DIFF
--- a/SwiftUIQuizz.xcodeproj/project.pbxproj
+++ b/SwiftUIQuizz.xcodeproj/project.pbxproj
@@ -16,8 +16,8 @@
 		185BB8162835202700BB689A /* correct.json in Resources */ = {isa = PBXBuildFile; fileRef = 185BB8142835202700BB689A /* correct.json */; };
 		18DF400E282A8402006B7254 /* MultipleChoiceButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DF400D282A8402006B7254 /* MultipleChoiceButton.swift */; };
 		23A73D02283686C700C611D4 /* Quicksand.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 23A73D01283686C700C611D4 /* Quicksand.ttf */; };
-		3D12614C283D237A0079E14B /* Manager.AnswerTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D12614B283D237A0079E14B /* Manager.AnswerTracker.swift */; };
 		3DFB3603283FA6560045D062 /* Manager.QuestionStash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFB3602283FA6560045D062 /* Manager.QuestionStash.swift */; };
+		3DFB3605283FB4580045D062 /* Manager.SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFB3604283FB4580045D062 /* Manager.SessionManager.swift */; };
 		3DFD23EE28295C180074AB54 /* Manager.SaveSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFD23ED28295C180074AB54 /* Manager.SaveSystem.swift */; };
 		5F0B738C283BACCE008EE6DC /* DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0B738B283BACCE008EE6DC /* DesignSystem.swift */; };
 		5F0B738E283BAD6E008EE6DC /* DesignSystem.Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0B738D283BAD6E008EE6DC /* DesignSystem.Color.swift */; };
@@ -49,8 +49,8 @@
 		185BB8142835202700BB689A /* correct.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = correct.json; sourceTree = "<group>"; };
 		18DF400D282A8402006B7254 /* MultipleChoiceButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleChoiceButton.swift; sourceTree = "<group>"; };
 		23A73D01283686C700C611D4 /* Quicksand.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Quicksand.ttf; sourceTree = "<group>"; };
-		3D12614B283D237A0079E14B /* Manager.AnswerTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Manager.AnswerTracker.swift; sourceTree = "<group>"; };
 		3DFB3602283FA6560045D062 /* Manager.QuestionStash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Manager.QuestionStash.swift; sourceTree = "<group>"; };
+		3DFB3604283FB4580045D062 /* Manager.SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Manager.SessionManager.swift; sourceTree = "<group>"; };
 		3DFD23ED28295C180074AB54 /* Manager.SaveSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Manager.SaveSystem.swift; sourceTree = "<group>"; };
 		5F0B738B283BACCE008EE6DC /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
 		5F0B738D283BAD6E008EE6DC /* DesignSystem.Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.Color.swift; sourceTree = "<group>"; };
@@ -137,8 +137,8 @@
 				5F3AC736282408250041CBBC /* Manager.API.swift */,
 				3DFD23ED28295C180074AB54 /* Manager.SaveSystem.swift */,
 				1830AF87283E4A5800D4EA1A /* Manager.SFX.swift */,
-				3D12614B283D237A0079E14B /* Manager.AnswerTracker.swift */,
 				3DFB3602283FA6560045D062 /* Manager.QuestionStash.swift */,
+				3DFB3604283FB4580045D062 /* Manager.SessionManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -338,8 +338,8 @@
 				18DF400E282A8402006B7254 /* MultipleChoiceButton.swift in Sources */,
 				5F0B738E283BAD6E008EE6DC /* DesignSystem.Color.swift in Sources */,
 				5F9C58ED2833D0B100070A37 /* ConclusionView.swift in Sources */,
+				3DFB3605283FB4580045D062 /* Manager.SessionManager.swift in Sources */,
 				5F0B7390283BC476008EE6DC /* Data.swift in Sources */,
-				3D12614C283D237A0079E14B /* Manager.AnswerTracker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftUIQuizz.xcodeproj/project.pbxproj
+++ b/SwiftUIQuizz.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		18DF400E282A8402006B7254 /* MultipleChoiceButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DF400D282A8402006B7254 /* MultipleChoiceButton.swift */; };
 		23A73D02283686C700C611D4 /* Quicksand.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 23A73D01283686C700C611D4 /* Quicksand.ttf */; };
 		3D12614C283D237A0079E14B /* Manager.AnswerTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D12614B283D237A0079E14B /* Manager.AnswerTracker.swift */; };
+		3DFB3603283FA6560045D062 /* Manager.QuestionStash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFB3602283FA6560045D062 /* Manager.QuestionStash.swift */; };
 		3DFD23EE28295C180074AB54 /* Manager.SaveSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFD23ED28295C180074AB54 /* Manager.SaveSystem.swift */; };
 		5F0B738C283BACCE008EE6DC /* DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0B738B283BACCE008EE6DC /* DesignSystem.swift */; };
 		5F0B738E283BAD6E008EE6DC /* DesignSystem.Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0B738D283BAD6E008EE6DC /* DesignSystem.Color.swift */; };
@@ -49,6 +50,7 @@
 		18DF400D282A8402006B7254 /* MultipleChoiceButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleChoiceButton.swift; sourceTree = "<group>"; };
 		23A73D01283686C700C611D4 /* Quicksand.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Quicksand.ttf; sourceTree = "<group>"; };
 		3D12614B283D237A0079E14B /* Manager.AnswerTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Manager.AnswerTracker.swift; sourceTree = "<group>"; };
+		3DFB3602283FA6560045D062 /* Manager.QuestionStash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Manager.QuestionStash.swift; sourceTree = "<group>"; };
 		3DFD23ED28295C180074AB54 /* Manager.SaveSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Manager.SaveSystem.swift; sourceTree = "<group>"; };
 		5F0B738B283BACCE008EE6DC /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
 		5F0B738D283BAD6E008EE6DC /* DesignSystem.Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.Color.swift; sourceTree = "<group>"; };
@@ -136,6 +138,7 @@
 				3DFD23ED28295C180074AB54 /* Manager.SaveSystem.swift */,
 				1830AF87283E4A5800D4EA1A /* Manager.SFX.swift */,
 				3D12614B283D237A0079E14B /* Manager.AnswerTracker.swift */,
+				3DFB3602283FA6560045D062 /* Manager.QuestionStash.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -319,6 +322,7 @@
 			files = (
 				5F3AC737282408250041CBBC /* Manager.API.swift in Sources */,
 				5FDC436D2829371100A4F011 /* LaunchView.swift in Sources */,
+				3DFB3603283FA6560045D062 /* Manager.QuestionStash.swift in Sources */,
 				5FE9134A2822A76E00C0CDE0 /* QuestionView.swift in Sources */,
 				3DFD23EE28295C180074AB54 /* Manager.SaveSystem.swift in Sources */,
 				5F0B738C283BACCE008EE6DC /* DesignSystem.swift in Sources */,

--- a/SwiftUIQuizz/Manager/Manager.AnswerTracker.swift
+++ b/SwiftUIQuizz/Manager/Manager.AnswerTracker.swift
@@ -21,7 +21,7 @@ extension Manager {
             self.wrongAnswers = 0
         }
 
-        func startQuiz(questionAmount: Int = 0) {
+        func resetTracker(questionAmount: Int = 0) {
             self.questionAmount = questionAmount
             self.correctAnswers = 0
             self.wrongAnswers = 0

--- a/SwiftUIQuizz/Manager/Manager.QuestionStash.swift
+++ b/SwiftUIQuizz/Manager/Manager.QuestionStash.swift
@@ -13,7 +13,7 @@ extension Manager {
         private static let fileName = "stash"
         private static let limit = 5000
 
-        private var questionDict: [String:Bool]
+        private var questionDict: [String: Bool]
         private var questionArray: [String]
 
         private static func loadFromStorage() -> QuestionStash {
@@ -29,7 +29,7 @@ extension Manager {
             questionArray = []
         }
 
-        private func saveToStorage(){
+        private func saveToStorage() {
             do {
                 try SaveSystem.saveObject(object: self, fileName: QuestionStash.fileName)
             } catch {

--- a/SwiftUIQuizz/Manager/Manager.QuestionStash.swift
+++ b/SwiftUIQuizz/Manager/Manager.QuestionStash.swift
@@ -1,0 +1,58 @@
+//
+//  Manager.QuestionStash.swift
+//  SwiftUIQuizz
+//
+//  Created by Henrique Finger Zimerman on 26/05/22.
+//
+
+import Foundation
+
+extension Manager {
+    class QuestionStash: Decodable, Encodable {
+        public static var shared = QuestionStash.loadFromStorage()
+        private static let fileName = "stash"
+        private static let limit = 5000
+
+        private var questionDict: [String:Bool]
+        private var questionArray: [String]
+
+        private static func loadFromStorage() -> QuestionStash {
+            guard let answer: QuestionStash = try? SaveSystem.readObject(fileName: QuestionStash.fileName)
+            else {
+               return QuestionStash()
+            }
+            return answer
+        }
+
+        private init() {
+            questionDict = [:]
+            questionArray = []
+        }
+
+        private func saveToStorage(){
+            do {
+                try SaveSystem.saveObject(object: self, fileName: QuestionStash.fileName)
+            } catch {
+                print(error)
+            }
+        }
+
+        public func isRepeatedQuestion(question: String) -> Bool {
+            if questionDict[question] == nil {
+                return false
+            }
+            return true
+        }
+
+        public func addQuestion(question: String, answerStatus: Bool = true) {
+            guard questionDict[question] == nil else {return}
+            questionDict[question] = answerStatus
+            questionArray.append(question)
+            if questionArray.count > QuestionStash.limit {
+                questionDict.removeValue(forKey: questionArray[0])
+                _ = questionArray.remove(at: 0)
+            }
+            saveToStorage()
+        }
+    }
+}

--- a/SwiftUIQuizz/Manager/Manager.SessionManager.swift
+++ b/SwiftUIQuizz/Manager/Manager.SessionManager.swift
@@ -1,0 +1,70 @@
+//
+//  Manager.SessionManager.swift
+//  SwiftUIQuizz
+//
+//  Created by Henrique Finger Zimerman on 26/05/22.
+//
+
+import Foundation
+
+extension Manager {
+    class SessionManager {
+        public static let shared = SessionManager()
+        private var questionArray: [Question] = []
+        private var questionIndex: Int = 0
+
+        var correctAnswers: Int = 0
+        var wrongAnswers: Int = 0
+        var questionAmount: Int = 0
+
+        enum Errors: Error {
+            case sessionEnded
+        }
+
+        private init() {
+        }
+
+        func startSession(
+            category: Manager.API.QuestionCategory,
+            difficulty: Manager.API.Difficulty,
+            answerType: Manager.API.AnswerTypes,
+            amount: Int = 10
+        ) async throws -> Bool {
+            questionIndex = 0
+            correctAnswers = 0
+            wrongAnswers = 0
+            questionArray = try await Manager.API.shared.fetchQuestions(category: category,
+                                                                        difficulty: difficulty,
+                                                                        answerType: answerType,
+                                                                        amount: amount)
+            questionAmount = amount
+            return true
+        }
+
+        func sessionEnded() -> Bool {
+            return questionIndex >= questionArray.count
+        }
+
+        func currentQuestion() throws -> Question {
+            guard !sessionEnded()
+            else {
+                throw Errors.sessionEnded
+            }
+            return questionArray[questionIndex]
+        }
+
+        func addResult(answerStatus: Bool) throws {
+            guard !sessionEnded()
+            else {
+                throw Errors.sessionEnded
+            }
+            if answerStatus {
+                correctAnswers += 1
+            } else {
+                wrongAnswers += 1
+            }
+            Manager.QuestionStash.shared.addQuestion(question: questionArray[questionIndex].question)
+            questionIndex += 1
+        }
+    }
+}

--- a/SwiftUIQuizz/Views/Buttons/BooleanButton.swift
+++ b/SwiftUIQuizz/Views/Buttons/BooleanButton.swift
@@ -27,7 +27,9 @@ extension Views {
                 action: {
                     isAnimating = true
                     Manager.SFX.playSound(sound: isCorrect ? .correct: .wrong)
-                    Manager.AnswerTracker.shared.addResult(answerStatus: isCorrect)
+                    do {
+                        try Manager.SessionManager.shared.addResult(answerStatus: isCorrect)
+                    } catch { print(error) }
                 }
             ) {
                 ZStack {

--- a/SwiftUIQuizz/Views/Buttons/MultipleChoiceButton.swift
+++ b/SwiftUIQuizz/Views/Buttons/MultipleChoiceButton.swift
@@ -27,7 +27,9 @@ extension Views {
                 action: {
                     isAnimating = true
                     Manager.SFX.playSound(sound: isCorrect ? .correct: .wrong)
-                    Manager.AnswerTracker.shared.addResult(answerStatus: isCorrect)
+                    do {
+                        try Manager.SessionManager.shared.addResult(answerStatus: isCorrect)
+                    } catch { print(error) }
                 }
             ) {
                 HStack {

--- a/SwiftUIQuizz/Views/ConclusionView.swift
+++ b/SwiftUIQuizz/Views/ConclusionView.swift
@@ -75,9 +75,9 @@ extension Views.ConclusionView {
     }
 
     class ViewModel: ObservableObject {
-        @Published var correctAnswers: Int = Manager.AnswerTracker.shared.correctAnswers
-        @Published var wrongAnswers: Int = Manager.AnswerTracker.shared.wrongAnswers
-        @Published var totalQuestions: Int = Manager.AnswerTracker.shared.questionAmount
+        @Published var correctAnswers: Int = Manager.SessionManager.shared.correctAnswers
+        @Published var wrongAnswers: Int = Manager.SessionManager.shared.wrongAnswers
+        @Published var totalQuestions: Int = Manager.SessionManager.shared.questionAmount
 
         func answerRate() -> Int {
             var rate: Double

--- a/SwiftUIQuizz/Views/InitialView.swift
+++ b/SwiftUIQuizz/Views/InitialView.swift
@@ -58,14 +58,15 @@ extension Views {
                         .navigationBarHidden(true)
                         .task {
                         do {
-                            Manager.AnswerTracker.shared.startQuiz(questionAmount: viewModel.numberQuestions)
-                            let questions = try await Manager.API.shared.fetchQuestions(
+                            let success = try await Manager.SessionManager.shared.startSession(
                                 category: Manager.API.QuestionCategory.allCases[selectedCategoryIndex],
                                 difficulty: Manager.API.Difficulty.allCases[selectedDifficultyIndex],
                                 answerType: Manager.API.AnswerTypes.allCases[selectedTypeIndex],
                                 amount: viewModel.numberQuestions
                             )
-                            questionsViewModel.update(question: questions.first!)
+                            if success {
+                                try questionsViewModel.update(question: Manager.SessionManager.shared.currentQuestion())
+                            }
                         } catch {
                             print(error)
                         }


### PR DESCRIPTION
- Created QuestionStash Singleton Class
- - Public methods:
- - public func isRepeatedQuestion(question: String) -> Bool
- - public func addQuestion(question: String, answerStatus: Bool = true)
- - Stash stores the last 5000 answered questions.
- Removed AnswerTracker class (incorporated into SessionManager).
- Added SessionManager Singleton Class:
- - Public methods:
- - func startSession(
            category: Manager.API.QuestionCategory,
            difficulty: Manager.API.Difficulty,
            answerType: Manager.API.AnswerTypes,
            amount: Int = 10
        ) async throws -> Bool
- - func sessionEnded() -> Bool
- - func currentQuestion() throws -> Question
- - func addResult(answerStatus: Bool) throws
- Modified API to include new methods:
- - fetchQuestions renamed to simpleFetch
- - added new method fetchQuestions which checks if a question is repeated and repeats the API call until the asked number of questions is obtained without repetition.
- Modified QuestionView and InitialView to work with session manager.
-  InitialView had data inside the view, passed it to ViewModel.

- Bug identified on both this branch and dev: Switching to the profile tab and then back to the quiz tab during a quiz session will cause weird behaviors. Added to issues.

Closes #11 ans #9 